### PR TITLE
refactor autocomplete to be flexible and reusable

### DIFF
--- a/src/AutoCrudAdmin/ViewModels/FormControlViewModel.cs
+++ b/src/AutoCrudAdmin/ViewModels/FormControlViewModel.cs
@@ -82,4 +82,14 @@ public class FormControlViewModel
     /// Gets or sets the entity id for the autocomplete feature of the form control.
     /// </summary>
     public string? FormControlAutocompleteEntityId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the entity property that autocomplete will search by.
+    /// </summary>
+    public string? SearchByPropertyAutocompleteConfiguration { get; set; }
+
+    /// <summary>
+    /// Gets or sets how much autocomplete results will be shown (20 by default).
+    /// </summary>
+    public int NumberOfAutocompleteItemsShownConfiguration { get; set; } = 20;
 }

--- a/src/AutoCrudAdmin/Views/Shared/_EnityFormControlsPartial.cshtml
+++ b/src/AutoCrudAdmin/Views/Shared/_EnityFormControlsPartial.cshtml
@@ -73,8 +73,10 @@
                    type: "GET",
            
                    url: `/${controllerName}/Autocomplete`,
-                   data: { 
-                     searchTerm: request.term
+                   data: {
+                        searchTerm: request.term,
+                        searchProperty: '@formControl.SearchByPropertyAutocompleteConfiguration',
+                        maxResults: @formControl.NumberOfAutocompleteItemsShownConfiguration,
                    },
                    success: function (data) {
                          response($.map(data, function (item) {


### PR DESCRIPTION
Closes https://github.com/Minkov/AutoCrudAdmin/issues/41

Summary of changes:

1. Removed hardcoded key "Id" and now keys are collected by GetPrimaryKeyPropertyInfos() so we can have multiple keys.
2. Refactor comparing logic to work with other then strings.
4. Add configurations for search property and number of items shown (default 20) in FormControlViewModel.