### PR TITLE
Fix bug with foreign keys not showing as form controls

### DIFF
--- a/src/AutoCrudAdmin/Helpers/ReflectionHelper.cs
+++ b/src/AutoCrudAdmin/Helpers/ReflectionHelper.cs
@@ -64,7 +64,7 @@ public static class ReflectionHelper
 
         var uniqueEntityTypes = entityTypes
             .Where(parent =>
-                parent?.IsGenericParameter == true
+                parent?.IsGenericParameter == false
                 && entityTypes.All(child => child?.IsSubclassOfAnyType(parent) != true))
             .ToHashSet();
 


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/1056

The issue is related to a simple technical error.

Before refactoring the code in question looked like this:

var uniqueEntityTypes = entityTypes
.Where(parent =>
!parent.IsGenericParameter
&& !entityTypes.Any(
child => child.IsSubclassOfAnyType(parent)))
.ToHashSet();

After refactoring the above snippet became this and foreign keys' properties stopped being displayed as form controls altogether:

var uniqueEntityTypes = entityTypes
.Where(parent =>
parent?.IsGenericParameter == true
&& entityTypes.All(child => child?.IsSubclassOfAnyType(parent) != true))
.ToHashSet();

After having set parent?.IsGenericParameter to false, everything works as expected.

Commit where the error is made: 44ed717d8dcf9a8e76af380ab26a558998536f16